### PR TITLE
feat: remove tags associated with the executions and consider them as part of context

### DIFF
--- a/src/engine/executionEngine.spec.ts
+++ b/src/engine/executionEngine.spec.ts
@@ -1,13 +1,12 @@
 import { ExecutionEngine } from './executionEngine';
 
-class TestExecutionEngine extends ExecutionEngine<{ user: { name?: string; age?: number }; itemsBought?: Array<string> }> {
+class TestExecutionEngine extends ExecutionEngine<{
+  user: { name?: string; age?: number };
+  itemsBought?: Array<string>;
+}> {
   // Expose protected members for testing
   constructor() {
     super({ executionId: 'customId' });
-  }
-
-  getTags() {
-    return this.tags;
   }
 }
 
@@ -17,7 +16,6 @@ describe('ExecutionEngine', () => {
     const execution = new TestExecutionEngine();
     expect(execution).toBeInstanceOf(TestExecutionEngine);
     expect(execution.getContext()).toBeUndefined();
-    expect(execution.getTags()).toEqual([]);
   });
 
   // Test case for setContext method
@@ -52,13 +50,5 @@ describe('ExecutionEngine', () => {
 
     const expectedContext = { user: { name: 'John', age: 25 } };
     expect(execution.getContext()).toEqual(expectedContext);
-  });
-
-  // Test case for tag method
-  test('should add a tag with tag method', () => {
-    const execution = new TestExecutionEngine();
-    const tag = 'important';
-    execution.tag(tag);
-    expect(execution.getTags()).toContain(tag);
   });
 });

--- a/src/engine/executionEngine.ts
+++ b/src/engine/executionEngine.ts
@@ -7,13 +7,12 @@ import { TraceableExecution } from '../trace/traceableExecution';
  * Represents a Contextual Execution with traceability features.
  *
  * @template CXT - Type of the context object.
- * @template TAG - Type of the tags associated with the execution.
  */
 export class ExecutionEngine<
-  CXT extends { [key: string]: unknown } = { [key: string]: unknown },
-  TAG extends string = string
+  CXT extends { [key: string]: unknown } = {
+    [key: string]: unknown;
+  }
 > extends TraceableExecution {
-  protected tags: Array<TAG> = [];
   protected context: CXT;
 
   protected executionDate: Date;
@@ -95,11 +94,6 @@ export class ExecutionEngine<
         ...partialContextAttribute
       };
     }
-    return this;
-  }
-
-  tag(tag: TAG) {
-    this.tags.push(tag);
     return this;
   }
 


### PR DESCRIPTION
⚠️ `tags` attribute no longer exist as a part of `ExecutionContext`, please consider enriching the `context` attribute with tas if you still want them