### PR TITLE
feat: rename `getOrderedNarratives` to `getNarratives`

### DIFF
--- a/src/engine/executionEngineDecorators.ts
+++ b/src/engine/executionEngineDecorators.ts
@@ -58,10 +58,11 @@ export function engine(options?: { id: string }): ClassDecorator {
 
 /**
  * A method decorator that enables tracing for the decorated method.
- * @param options - Trace options for the execution.
- * @returns A decorator function.
+ *
+ * @param {TraceOptions<Array<any>, O> | TraceOptions<Array<any>, O>['trace']} [options] - Optional tracing options.
+ * @returns {Function} - A decorator function.
  */
-export function run<O>(options?: TraceOptions<Array<any>, O>) {
+export function run<O>(options?: TraceOptions<Array<any>, O> | TraceOptions<Array<any>, O>['trace']) {
   return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
     // Store the original method
     const originalMethod = descriptor.value;

--- a/src/trace/traceableExecution.spec.ts
+++ b/src/trace/traceableExecution.spec.ts
@@ -298,7 +298,7 @@ describe('TraceableExecution', () => {
       ]);
 
       // Get the ordered narratives and verify their content
-      const orderedNarratives = traceableExecution.getOrderedNarratives();
+      const orderedNarratives = traceableExecution.getNarratives();
       expect(orderedNarratives).toEqual([
         'Narrative 0',
         'Narrative 0 with Result: InputParam',

--- a/src/trace/traceableExecution.ts
+++ b/src/trace/traceableExecution.ts
@@ -309,10 +309,11 @@ export class TraceableExecution {
   }
 
   /**
-   * Gets an ordered array of narratives.
-   * @returns An array containing ordered narratives.
+   * Retrieves an ordered array of narratives.
+   *
+   * @returns {Array<string>} An array that contains the ordered narratives. If no narratives are found, an empty array is returned.
    */
-  getOrderedNarratives(): Array<string> {
+  getNarratives(): Array<string> {
     return this.nodes?.flatMap?.((n) => n.data?.narratives)?.filter((n) => !!n);
   }
 

--- a/src/trace/traceableExecution.ts
+++ b/src/trace/traceableExecution.ts
@@ -86,10 +86,17 @@ export class TraceableExecution {
     }
   }
 
-  initTrace(initialTrace: Trace) {
+  /**
+   * Initializes the trace with given initialTrace.
+   *
+   * @param {Trace} initialTrace - The initial trace to initialize: the nodes and edges.
+   * @return {TraceableExecution} - The traceable execution object after initialization.
+   */
+  initTrace(initialTrace: Trace): TraceableExecution {
     this.nodes = (initialTrace?.filter((b) => b.group === 'nodes') as Array<Node>) ?? [];
     this.edges = (initialTrace?.filter((b) => b.group === 'edges') as Array<Edge>) ?? [];
     this.narrativesForNonFoundNodes = {};
+    return this;
   }
 
   /**


### PR DESCRIPTION
⚠️ BREAKING CHANGE: Replace `getOrderedNarratives` method with `getNarratives`