### PR TITLE
fix: add bypass argument to cache execution

### DIFF
--- a/src/common/models/executionCache.model.ts
+++ b/src/common/models/executionCache.model.ts
@@ -24,16 +24,22 @@ export interface CacheContext<O = unknown> {
   /** Unique key identifying the cache entry. */
   cacheKey: string;
 
+
   /** The time-to-live (TTL) for the cache entry. */
   ttl: number;
 
-  /** Flag indicating whether the value is cached. */
+  /**  Flag indicating whether the cached value is bypassed and a fresh computation is triggered. */
+  isBypassed: boolean;
+
+  /**
+   *  Flag indicating whether the value is found in the cache.
+   * @remarks: To confirm it was retrieved from cache, ensure `isBypassed` is `false`.
+   * */
   isCached: boolean;
 
   /** The cached value, if any. */
   value?: O;
 }
-
 
 /**
  * Configuration options for caching behavior.
@@ -41,6 +47,9 @@ export interface CacheContext<O = unknown> {
 export interface CacheOptions<O = unknown> {
   /** Time-to-live (TTL) for cache items. Can be static (number) or dynamic (function that returns a number). */
   ttl: number | ((params: { metadata: FunctionMetadata; inputs: unknown[] }) => number);
+
+  /** A function that returns `true` to ignore existing cache and force a fresh computation. Defaults to `false`. */
+  bypass?: (params: { metadata: FunctionMetadata; inputs: unknown[] }) => boolean;
 
   /** Function to generate a custom cache key based on method metadata and arguments. */
   cacheKey?: (params: { metadata: FunctionMetadata; inputs: unknown[] }) => string;

--- a/src/execution/cache.decorator.ts
+++ b/src/execution/cache.decorator.ts
@@ -23,6 +23,7 @@ export function cache(options: CacheOptions): MethodDecorator {
         functionId: thisMethodMetadata.methodSignature as string,
         ...options,
         cacheKey: attachFunctionMetadata.bind(this)(options.cacheKey, thisMethodMetadata),
+        bypass: attachFunctionMetadata.bind(this)(options.bypass, thisMethodMetadata),
         ttl: attachFunctionMetadata.bind(this)(options.ttl, thisMethodMetadata),
         onCacheEvent: attachFunctionMetadata.bind(this)(options.onCacheEvent, thisMethodMetadata)
       });

--- a/src/execution/trace.decorator.spec.ts
+++ b/src/execution/trace.decorator.spec.ts
@@ -172,8 +172,8 @@ describe('trace decorator', () => {
         url: string,
         traceContext: Record<string, unknown> = {}
       ): Promise<{
-        data: string;
-      }> {
+          data: string;
+        }> {
         return this.fetchDataFunction(url, traceContext);
       }
 


### PR DESCRIPTION
It's possible now to bypass existing cached value dynamically through a provided function,

Example:

```typescript
import { cache } from "execution-engine";

class ExampleService {
  @cache({ ttl: 5000, bypass: () => true })  // Store result for 5 seconds BUT bypass it
  async fetchData(id: number): Promise<string> {
    console.log('Fetching data...');
    return `Data for ${id}`;
  }
}

const service = new ExampleService();
console.log(await service.fetchData(1));  // Fetches data and stores it
console.log(await service.fetchData(1));  // DO NOT REUSE stored result bypass it instead

```